### PR TITLE
[TwitterBridge] URL to js file with apikey changed. (#1686)

### DIFF
--- a/bridges/TwitterBridge.php
+++ b/bridges/TwitterBridge.php
@@ -377,8 +377,15 @@ EOD;
 		if($data === null || (time() - $refresh) > self::GUEST_TOKEN_EXPIRY) {
 			$twitterPage = getContents('https://twitter.com');
 
-			$jsMainRegex = '/(https:\/\/abs\.twimg\.com\/responsive-web\/web_legacy\/main\.[^\.]+\.js)/m';
+			$jsMainRegex = '/(https:\/\/abs\.twimg\.com\/responsive-web\/web\/main\.[^\.]+\.js)/m';
 			preg_match_all($jsMainRegex, $twitterPage, $jsMainMatches, PREG_SET_ORDER, 0);
+			if (!$jsMainMatches) {
+				$jsMainRegex = '/(https:\/\/abs\.twimg\.com\/responsive-web\/web_legacy\/main\.[^\.]+\.js)/m';
+				preg_match_all($jsMainRegex, $twitterPage, $jsMainMatches, PREG_SET_ORDER, 0);
+			}
+			if (!$jsMainMatches) {
+				 returnServerError('Could not locate main.js link');
+			}
 			$jsLink = $jsMainMatches[0][0];
 
 			$jsContent = getContents($jsLink);


### PR DESCRIPTION
Twitter has changed URL scheme back again (see PR#1647 / commit 78298385d0016a7db8ed00894d9004429d24e77d)

This patch will try both URL schemes now and throw a specific error when neither works