### PR TITLE
[CI] Tag docker images with the commit sha (#2418)

### DIFF
--- a/.github/workflows/dockerbuild.yml
+++ b/.github/workflows/dockerbuild.yml
@@ -28,6 +28,7 @@ jobs:
             ${{ env.GHCR_SLUG }}
           tags: |
             type=raw,value=latest
+            type=sha
             type=ref,event=tag,enable=${{ startsWith(github.ref, 'refs/tags/20') }}
             type=raw,value=stable,enable=${{ startsWith(github.ref, 'refs/tags/20') }}
       -


### PR DESCRIPTION
We do not release stable tags often. To avoid using `latest`, for instance in Kubernetes manifests, this change allows to reference a repository commit. This way it is easy to lock image to a specific commit, and try and rollback if a change to a newer commit brings regressions.