### PR TITLE
[GiphyBridge] Lazy load images (#2512)

### DIFF
--- a/bridges/GiphyBridge.php
+++ b/bridges/GiphyBridge.php
@@ -50,6 +50,7 @@ class GiphyBridge extends BridgeAbstract {
 				'content'	=> <<<HTML
 <a href="{$entry->url}">
 <img
+	loading="lazy"
 	src="{$entry->images->downsized->url}"
 	width="{$entry->images->downsized->width}"
 	height="{$entry->images->downsized->height}" />


### PR DESCRIPTION
This change instructs browsers to gradually load images
as the user is scrolling down. This is good for performance
because browsers wont download all images right away.