### PR TITLE
Do not use constants for configuration (#2938)

### DIFF
--- a/actions/DisplayAction.php
+++ b/actions/DisplayAction.php
@@ -43,7 +43,7 @@ class DisplayAction implements ActionInterface
         $noproxy = array_key_exists('_noproxy', $request)
             && filter_var($request['_noproxy'], FILTER_VALIDATE_BOOLEAN);
 
-        if (defined('PROXY_URL') && PROXY_BYBRIDGE && $noproxy) {
+        if (Configuration::getConfig('proxy', 'url') && Configuration::getConfig('proxy', 'by_bridge') && $noproxy) {
             define('NOPROXY', true);
         }
 

--- a/docs/02_CLI/index.md
+++ b/docs/02_CLI/index.md
@@ -27,9 +27,9 @@ This parameter specifies the format in which RSS-Bridge returns the contents. RS
 
 RSS-Bridge supports optional parameters. These parameters are only valid if the options have been enabled in the index.php script.
 
-### _noproxy
+### \_noproxy
 
-This parameter is only available if a proxy server has been specified via `PROXY_URL` and 'PROXY_BYBRIDGE' has been enabled. This is a Boolean parameter that can be set to '1' (true) or '0' (false).
+This parameter is only available if a proxy server has been specified via `proxy.url` and `proxy.by_bridge` has been enabled. This is a Boolean parameter that can be set to `true` or `false`.
 
 ## Bridge parameters
 

--- a/docs/03_For_Hosts/07_Customizations.md
+++ b/docs/03_For_Hosts/07_Customizations.md
@@ -1,9 +1,9 @@
-RSS-Bridge ships a few options the host may or may not activate. All options are currently defined in the [index.php](https://github.com/RSS-Bridge/rss-bridge/blob/master/index.php) file. This means they'll be reset after upgrading RSS-Bridge!
+RSS-Bridge ships a few options the host may or may not activate. All options are listed in the [config.default.ini.php](https://github.com/RSS-Bridge/rss-bridge/blob/master/config.default.ini.php) file, see [Custom Configuration](08_Custom_Configuration.md) section for more information.
 
 ## Customizable cache timeout
 
 Sometimes it is necessary to specify custom timeouts to update contents more frequently than the bridge maintainer intended. In these cases the client may specify a custom cache timeout to prevent loading contents from cache earlier (or later).
 
-This option can be activated by setting the `CUSTOM_CACHE_TIMEOUT` to `true`. When enabled each bridge receives an additional parameter `Cache timeout in seconds` that can be set to any value between 1 and 86400 (24 hours). If the value is not within the limits the default settings apply (as specified by the bridge maintainer).
+This option can be activated by setting the [`cache.custom_timeout`](08_Custom_Configuration.md#custom_timeout) option to `true`. When enabled each bridge receives an additional parameter `Cache timeout in seconds` that can be set to any value between 1 and 86400 (24 hours). If the value is not within the limits the default settings apply (as specified by the bridge maintainer).
 
 The cache timeout is send to RSS-Bridge using the `_cache_timeout` parameter. RSS-Bridge will return an error message if the parameter is received and the option is disabled.

--- a/docs/03_For_Hosts/08_Custom_Configuration.md
+++ b/docs/03_For_Hosts/08_Custom_Configuration.md
@@ -17,7 +17,7 @@ __Notice__: If a parameter is not specified in your `config.ini.php` RSS-Bridge 
 The configuration file is split into sections:
 
 * [system](#system)
-* [http client](#http client)
+* [http client](#http-client)
 * [cache](#cache)
 * [proxy](#proxy)
 * [authentication](#authentication)

--- a/lib/BridgeCard.php
+++ b/lib/BridgeCard.php
@@ -324,9 +324,9 @@ This bridge is not fetching its content through a secure connection</div>';
 
         $donationsAllowed = Configuration::getConfig('admin', 'donations');
 
-        if (defined('PROXY_URL') && PROXY_BYBRIDGE) {
+        if (Configuration::getConfig('proxy', 'url') && Configuration::getConfig('proxy', 'by_bridge')) {
             $parameters['global']['_noproxy'] = [
-                'name' => 'Disable proxy (' . ((defined('PROXY_NAME') && PROXY_NAME) ? PROXY_NAME : PROXY_URL) . ')',
+                'name' => 'Disable proxy (' . (Configuration::getConfig('proxy', 'name') ?: Configuration::getConfig('proxy', 'url')) . ')',
                 'type' => 'checkbox'
             ];
         }

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -168,27 +168,19 @@ final class Configuration
         date_default_timezone_set(self::getConfig('system', 'timezone'));
 
         if (!is_string(self::getConfig('proxy', 'url'))) {
+            /** URL of the proxy server */
             self::reportConfigurationError('proxy', 'url', 'Is not a valid string');
         }
 
-        if (!empty(self::getConfig('proxy', 'url'))) {
-            /** URL of the proxy server */
-            define('PROXY_URL', self::getConfig('proxy', 'url'));
-        }
-
+        /** True if proxy usage can be enabled selectively for each bridge */
         if (!is_bool(self::getConfig('proxy', 'by_bridge'))) {
             self::reportConfigurationError('proxy', 'by_bridge', 'Is not a valid Boolean');
         }
 
-        /** True if proxy usage can be enabled selectively for each bridge */
-        define('PROXY_BYBRIDGE', self::getConfig('proxy', 'by_bridge'));
-
         if (!is_string(self::getConfig('proxy', 'name'))) {
+            /** Name of the proxy server */
             self::reportConfigurationError('proxy', 'name', 'Is not a valid string');
         }
-
-        /** Name of the proxy server */
-        define('PROXY_NAME', self::getConfig('proxy', 'name'));
 
         if (!is_string(self::getConfig('cache', 'type'))) {
             self::reportConfigurationError('cache', 'type', 'Is not a valid string');

--- a/lib/contents.php
+++ b/lib/contents.php
@@ -79,8 +79,8 @@ function getContents(
         'headers' => $httpHeaders,
         'curl_options' => $curlOptions,
     ];
-    if (defined('PROXY_URL') && !defined('NOPROXY')) {
-        $config['proxy'] = PROXY_URL;
+    if (Configuration::getConfig('proxy', 'url') && !defined('NOPROXY')) {
+        $config['proxy'] = Configuration::getConfig('proxy', 'url');
     }
     if (!Debug::isEnabled() && $cache->getTime()) {
         $config['if_not_modified_since'] = $cache->getTime();


### PR DESCRIPTION
* docs: Do not use constant names when referring to config options

The options are customizable using a config file and no longer hardcoded in index.php since https://github.com/RSS-Bridge/rss-bridge/commit/8ac8e08abf25ac43b660e7e3c0b7485f4f6628d7

* Do not use constants for configuration

Since <https://github.com/RSS-Bridge/rss-bridge/commit/8ac8e08abf25ac43b660e7e3c0b7485f4f6628d7>, they are just set to the configuration object values.