### PR TITLE
refactor: use static values for cache scope

### DIFF
--- a/bridges/ElloBridge.php
+++ b/bridges/ElloBridge.php
@@ -116,7 +116,7 @@ class ElloBridge extends BridgeAbstract
         $cacheFactory = new CacheFactory();
 
         $cache = $cacheFactory->create();
-        $cache->setScope(get_called_class());
+        $cache->setScope('ElloBridge');
         $cache->setKey(['key']);
         $key = $cache->loadData();
 

--- a/bridges/InstagramBridge.php
+++ b/bridges/InstagramBridge.php
@@ -101,7 +101,7 @@ class InstagramBridge extends BridgeAbstract
         $cacheFactory = new CacheFactory();
 
         $cache = $cacheFactory->create();
-        $cache->setScope(get_called_class());
+        $cache->setScope('InstagramBridge');
         $cache->setKey([$username]);
         $key = $cache->loadData();
 

--- a/bridges/SoundcloudBridge.php
+++ b/bridges/SoundcloudBridge.php
@@ -125,7 +125,7 @@ HTML;
         $cacheFactory = new CacheFactory();
 
         $this->clientIDCache = $cacheFactory->create();
-        $this->clientIDCache->setScope(get_called_class());
+        $this->clientIDCache->setScope('SoundCloudBridge');
         $this->clientIDCache->setKey(['client_id']);
     }
 

--- a/bridges/SpotifyBridge.php
+++ b/bridges/SpotifyBridge.php
@@ -103,7 +103,7 @@ class SpotifyBridge extends BridgeAbstract
         $cacheFactory = new CacheFactory();
 
         $cache = $cacheFactory->create();
-        $cache->setScope(get_called_class());
+        $cache->setScope('SpotifyBridge');
         $cache->setKey(['token']);
 
         if ($cache->getTime()) {

--- a/bridges/TwitterBridge.php
+++ b/bridges/TwitterBridge.php
@@ -506,7 +506,8 @@ EOD;
         $cacheFactory = new CacheFactory();
 
         $r_cache = $cacheFactory->create();
-        $r_cache->setScope(get_called_class());
+        $scope = 'TwitterBridge';
+        $r_cache->setScope($scope);
         $r_cache->setKey(['refresh']);
         $data = $r_cache->loadData();
 
@@ -521,7 +522,7 @@ EOD;
         $cacheFactory = new CacheFactory();
 
         $cache = $cacheFactory->create();
-        $cache->setScope(get_called_class());
+        $cache->setScope($scope);
         $cache->setKey(['api_key']);
         $data = $cache->loadData();
 
@@ -558,7 +559,7 @@ EOD;
         $cacheFac2 = new CacheFactory();
 
         $gt_cache = $cacheFactory->create();
-        $gt_cache->setScope(get_called_class());
+        $gt_cache->setScope($scope);
         $gt_cache->setKey(['guest_token']);
         $guestTokenUses = $gt_cache->loadData();
 

--- a/caches/MemcachedCache.php
+++ b/caches/MemcachedCache.php
@@ -15,22 +15,23 @@ class MemcachedCache implements CacheInterface
             returnServerError('"memcached" extension not loaded. Please check "php.ini"');
         }
 
-        $host = Configuration::getConfig(get_called_class(), 'host');
-        $port = Configuration::getConfig(get_called_class(), 'port');
+        $section = 'MemcachedCache';
+        $host = Configuration::getConfig($section, 'host');
+        $port = Configuration::getConfig($section, 'port');
         if (empty($host) && empty($port)) {
-            returnServerError('Configuration for ' . get_called_class() . ' missing. Please check your ' . FILE_CONFIG);
+            returnServerError('Configuration for ' . $section . ' missing. Please check your ' . FILE_CONFIG);
         } elseif (empty($host)) {
-            returnServerError('"host" param is not set for ' . get_called_class() . '. Please check your ' . FILE_CONFIG);
+            returnServerError('"host" param is not set for ' . $section . '. Please check your ' . FILE_CONFIG);
         } elseif (empty($port)) {
-            returnServerError('"port" param is not set for ' . get_called_class() . '. Please check your ' . FILE_CONFIG);
+            returnServerError('"port" param is not set for ' . $section . '. Please check your ' . FILE_CONFIG);
         } elseif (!ctype_digit($port)) {
-            returnServerError('"port" param is invalid for ' . get_called_class() . '. Please check your ' . FILE_CONFIG);
+            returnServerError('"port" param is invalid for ' . $section . '. Please check your ' . FILE_CONFIG);
         }
 
         $port = intval($port);
 
         if ($port < 1 || $port > 65535) {
-            returnServerError('"port" param is invalid for ' . get_called_class() . '. Please check your ' . FILE_CONFIG);
+            returnServerError('"port" param is invalid for ' . $section . '. Please check your ' . FILE_CONFIG);
         }
 
         $conn = new Memcached();

--- a/caches/SQLiteCache.php
+++ b/caches/SQLiteCache.php
@@ -24,16 +24,17 @@ class SQLiteCache implements CacheInterface
             );
         }
 
-        $file = Configuration::getConfig(get_called_class(), 'file');
+        $section = 'SQLiteCache';
+        $file = Configuration::getConfig($section, 'file');
         if (empty($file)) {
-            $message = sprintf('Configuration for %s missing. Please check your %s', get_called_class(), FILE_CONFIG);
+            $message = sprintf('Configuration for %s missing. Please check your %s', $section, FILE_CONFIG);
             print render('error.html.php', ['message' => $message]);
             exit;
         }
         if (dirname($file) == '.') {
             $file = PATH_CACHE . $file;
         } elseif (!is_dir(dirname($file))) {
-            $message = sprintf('Invalid configuration for %s. Please check your %s', get_called_class(), FILE_CONFIG);
+            $message = sprintf('Invalid configuration for %s. Please check your %s', $section, FILE_CONFIG);
             print render('error.html.php', ['message' => $message]);
             exit;
         }

--- a/index.php
+++ b/index.php
@@ -4,6 +4,11 @@ require_once __DIR__ . '/lib/rssbridge.php';
 
 Configuration::verifyInstallation();
 Configuration::loadConfiguration();
+
+date_default_timezone_set(Configuration::getConfig('system', 'timezone'));
+
+define('CUSTOM_CACHE_TIMEOUT', Configuration::getConfig('cache', 'custom_timeout'));
+
 Authentication::showPromptIfNeeded();
 
 try {

--- a/lib/BridgeAbstract.php
+++ b/lib/BridgeAbstract.php
@@ -280,7 +280,8 @@ abstract class BridgeAbstract implements BridgeInterface
     public function loadConfiguration()
     {
         foreach (static::CONFIGURATION as $optionName => $optionValue) {
-            $configurationOption = Configuration::getConfig(get_class($this), $optionName);
+            $section = (new ReflectionClass($this))->getShortName();
+            $configurationOption = Configuration::getConfig($section, $optionName);
 
             if ($configurationOption !== null) {
                 $this->configuration[$optionName] = $configurationOption;
@@ -408,7 +409,9 @@ abstract class BridgeAbstract implements BridgeInterface
         $cacheFactory = new CacheFactory();
 
         $cache = $cacheFactory->create();
-        $cache->setScope(get_called_class());
+        // Create class name without the namespace part
+        $scope = (new ReflectionClass($this))->getShortName();
+        $cache->setScope($scope);
         $cache->setKey($key);
         if ($cache->getTime() < time() - $duration) {
             return null;
@@ -427,7 +430,8 @@ abstract class BridgeAbstract implements BridgeInterface
         $cacheFactory = new CacheFactory();
 
         $cache = $cacheFactory->create();
-        $cache->setScope(get_called_class());
+        $scope = (new ReflectionClass($this))->getShortName();
+        $cache->setScope($scope);
         $cache->setKey($key);
         $cache->saveData($value);
     }

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -21,11 +21,5 @@ final class ConfigurationTest extends TestCase
 
         // test value from env
         $this->assertSame('Europe/Berlin', Configuration::getConfig('system', 'timezone'));
-
-        // test real values
-        $this->assertSame('file', Configuration::getConfig('cache', 'type'));
-        $this->assertSame(false, Configuration::getConfig('authentication', 'enable'));
-        $this->assertSame(true, Configuration::getConfig('admin', 'donations'));
-        $this->assertSame(1, Configuration::getConfig('error', 'report_limit'));
     }
 }


### PR DESCRIPTION
This fixes a future problem when code is placed under a namespace because `get_class($bridge)` will then return e.g. `RssBridge\Bridge\TwitterBridge` instead of the the current value `TwitterBridge`.

Also a bit refactoring of `Configuration.php`.